### PR TITLE
Add missing dependency on z3c.recipe.scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ requires = [
     'zope.testing',
     'zope.testrunner',
     'zc.recipe.egg',
+    'z3c.recipe.scripts'
 ]
 
 if sys.version_info < (2, 5):


### PR DESCRIPTION
Yo, a quick fix for 1.2.8 adding z3c.recipe.scripts as a dependency.
