### PR TITLE
Support for custom init code in virtualenv

### DIFF
--- a/collective/xmltestreport/recipe.py
+++ b/collective/xmltestreport/recipe.py
@@ -105,6 +105,7 @@ class TestRunner:
                             for p in test_paths)
                     +'        ]'),
             script_initialization=initialization,
+            initialization=initialization,
             ))
 
         return generated


### PR DESCRIPTION
Otherwise, initialization section and environment section are
completely missing from generated test script, when buildout is run
under virtualenv.

See buildout/buildout#20 for more info.

Fixes collective/collective.xmltestreport#8.