### PR TITLE
Extend UnicodeDecodeError fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed UnicodeDecodeError when exception message contains non-ascii, the fix in
+  1.3.4 only covered failures that had this problem.
+  [MatthewWilkes]
 
 
 1.3.4 (2017-02-02)

--- a/collective/xmltestreport/formatter.py
+++ b/collective/xmltestreport/formatter.py
@@ -250,6 +250,9 @@ class XMLOutputFormattingWrapper(object):
                         excType, excInstance, tb = testCase.error
                         errorMessage = str(excInstance)
                         stackTrace = ''.join(traceback.format_tb(tb))
+                    except UnicodeEncodeError:
+                        errorMessage = 'Could not extract error str for unicode error'
+                        stackTrace = ''.join(traceback.format_tb(tb))
                     finally: # Avoids a memory leak
                         del tb
 


### PR DESCRIPTION
Fix cases where the execInstance for errored test cases can't be coerced to ASCII using `errorMessage = str(excInstance)`.

This is an extension to the fix in #17 