### PR TITLE
Add compatibility with zope.testrunner 5.1+.

### DIFF
--- a/collective/xmltestreport/formatter.py
+++ b/collective/xmltestreport/formatter.py
@@ -145,13 +145,22 @@ class XMLOutputFormattingWrapper(object):
     def __getattr__(self, name):
         return getattr(self.delegate, name)
 
-    def test_failure(self, test, seconds, exc_info):
+    def test_failure(self, test, seconds, exc_info, stdout=None, stderr=None):
         self._record(test, seconds, failure=exc_info)
-        return self.delegate.test_failure(test, seconds, exc_info)
+        # stdout and stderr are only passed into us by zope.testrunner 5.1+
+        # and then only when using buffering (--buffer).
+        # self.delegate also comes from zope.testrunner then.
+        if stdout is None and stderr is None:
+            # the normal case
+            return self.delegate.test_failure(test, seconds, exc_info)
+        return self.delegate.test_failure(test, seconds, exc_info, stdout=stdout, stderr=stderr)
 
-    def test_error(self, test, seconds, exc_info):
+    def test_error(self, test, seconds, exc_info, stdout=None, stderr=None):
         self._record(test, seconds, error=exc_info)
-        return self.delegate.test_error(test, seconds, exc_info)
+        if stdout is None and stderr is None:
+            # the normal case
+            return self.delegate.test_error(test, seconds, exc_info)
+        return self.delegate.test_error(test, seconds, exc_info, stdout=stdout, stderr=stderr)
 
     def test_success(self, test, seconds):
         self._record(test, seconds)

--- a/news/103.bugfix
+++ b/news/103.bugfix
@@ -1,0 +1,3 @@
+Add compatibility with `zope.testrunner` 5.1+.
+Fixes https://github.com/zopefoundation/zope.testrunner/issues/103
+[maurits]


### PR DESCRIPTION
Plone 6.0 now tries to use Zope 4.2.1, which includes a new `zope.testrunner` 5.1.  That gives trouble when there is an error:

```
TypeError: test_failure() got an unexpected keyword argument 'stdout'
```

Originally reported by me in https://github.com/zopefoundation/zope.testrunner/issues/103

Note that I see lots of failures om Plone 6 after this, but at least now they are visible.